### PR TITLE
bump nginx-proxy and acme-companion to latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging:
 
 services:
   nginx-proxy:
-    image: nginxproxy/nginx-proxy:0.9
+    image: nginxproxy/nginx-proxy:1.6
     ports:
       - "0.0.0.0:80:80"
       - "0.0.0.0:443:443"
@@ -26,7 +26,7 @@ services:
     logging: *default-logging
     restart: always
   nginx-proxy-acme:
-    image: nginxproxy/acme-companion:v1.13
+    image: nginxproxy/acme-companion:2.4
     volumes:
       - ./config/vhost.d:/etc/nginx/vhost.d
       - ./config/html:/usr/share/nginx/html


### PR DESCRIPTION
Current setup is a bit dated (last updated 3 years ago), seems to be a drop in upgrade (testing on abb-bulstronk)